### PR TITLE
changing waypoints_tree as (conventionally) non-private variable since it is to be used in the tl_detector.py.

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -10,6 +10,7 @@ from light_classification.tl_classifier import TLClassifier
 import tf
 import cv2
 import yaml
+from scipy.spatial import KDTree
 
 STATE_COUNT_THRESHOLD = 3
 
@@ -48,6 +49,7 @@ class TLDetector(object):
         self.last_state = TrafficLight.UNKNOWN
         self.last_wp = -1
         self.state_count = 0
+        self.__waypoints_tree = None
 
         rospy.spin()
 
@@ -56,6 +58,10 @@ class TLDetector(object):
 
     def waypoints_cb(self, waypoints):
         self.waypoints = waypoints
+        if not self.__waypoints_tree:
+            self.__base_waypoints = waypoints.waypoints
+            self.__base_waypoints_array = [[w.pose.pose.position.x, w.pose.pose.position.y] for w in self.__base_waypoints]
+            self.__waypoints_tree = KDTree(self.__base_waypoints_array)
 
     def traffic_cb(self, msg):
         self.lights = msg.lights
@@ -100,9 +106,7 @@ class TLDetector(object):
             int: index of the closest waypoint in self.waypoints
 
         """
-        #TODO implement
-        self.waypoints
-        return 0
+        return self.__waypoints_tree.query([x, y])[1]
 
     def get_light_state(self, light):
         """Determines the current color of the traffic light

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -92,8 +92,10 @@ class TLDetector(object):
             self.last_state = self.state
             light_wp = light_wp if state == TrafficLight.RED else -1
             self.last_wp = light_wp
+            rospy.loginfo('submitting = '+str(light_wp))
             self.upcoming_red_light_pub.publish(Int32(light_wp))
         else:
+            rospy.loginfo('submitting els = '+str(self.last_wp))
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
         self.state_count += 1
 
@@ -128,6 +130,7 @@ class TLDetector(object):
         #Get classification
         #return self.light_classifier.get_classification(cv_image)
         # TODO: call the claffier instead of using the one you get from simulator.
+        rospy.loginfo('got state = '+str(light.state))
         return light.state
 
     def process_traffic_lights(self):

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -60,9 +60,8 @@ class TLDetector(object):
     def waypoints_cb(self, waypoints):
         self.waypoints = waypoints
         if not self.__waypoints_tree:
-            self.__base_waypoints = waypoints.waypoints
-            self.__base_waypoints_array = [[w.pose.pose.position.x, w.pose.pose.position.y] for w in self.__base_waypoints]
-            self.__waypoints_tree = KDTree(self.__base_waypoints_array)
+            base_waypoints_array = [[w.pose.pose.position.x, w.pose.pose.position.y] for w in waypoints.waypoints]
+            self.__waypoints_tree = KDTree(base_waypoints_array)
 
     def traffic_cb(self, msg):
         self.lights = msg.lights
@@ -92,8 +91,10 @@ class TLDetector(object):
             self.last_state = self.state
             light_wp = light_wp if state == TrafficLight.RED else -1
             self.last_wp = light_wp
+            rospy.logdebug('publishing '+str(light_wp))
             self.upcoming_red_light_pub.publish(Int32(light_wp))
         else:
+            rospy.logdebug('publishing es '+str(self.last_wp))
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
         self.state_count += 1
 

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -147,14 +147,14 @@ class TLDetector(object):
         # we want to find closest light and the closest way point to that light. i.e. for a traffic light
         # we have a line at which we should stop so find a waypoint that is closest to the line
         # at which we should stop. line_wp_index is updated with that.
-        light = None
-        light_wp = None
+        closest_light = None
+        line_wp_idx = None
 
         # List of positions that correspond to the line to stop in front of for a given intersection
         stop_line_positions = self.config['stop_line_positions']
         # If we have pose of the car then only.
         if(self.pose):
-            car_position = self.get_closest_waypoint(self.pose.pose.position.x, self.pose.pose.position.y)
+            car_wp_idx = self.get_closest_waypoint(self.pose.pose.position.x, self.pose.pose.position.y)
             # Find the closest visible traffic light (if one exist)
             # Thie diff here indicates number of waypoints that we have generated.
             # We want to find whether one of the waypoints that we have generated lies on
@@ -165,7 +165,7 @@ class TLDetector(object):
             # stop at the stop line.
             # Get the closest traffic light's stop line.
             # Exhaustive search doesn't hurt as we don't have a lot of traffic lights to search.
-            for i, lt in enumerate(self.lights):
+            for i, light in enumerate(self.lights):
                 # Get the line to stop at for this traffic light
                 line = stop_line_positions[i]
                 # Get the closest way point to the stop line
@@ -173,18 +173,18 @@ class TLDetector(object):
                 # check whether this stop line is the closest one so far. If so, update this
                 # stop line as intended stop line. If the closest one lies out of the current waypoints
                 # list than don't consider it, hence d < diff condition
-                d = temp_wp_idx - car_position
+                d = temp_wp_idx - car_wp_idx
                 # if the closest
-        	rospy.loginfo("light state "+str(lt.state))
+                rospy.loginfo("light state "+str(light.state))
                 if d >= 0 and d < diff:
                     diff = d
-                    light = lt
-                    light_wp = temp_wp_idx
+                    closest_light = light
+                    line_wp_idx = temp_wp_idx
 
-        if light:
-            state = self.get_light_state(light)
-            return light_wp, state
-        self.waypoints = None
+        if closest_light:
+            state = self.get_light_state(closest_light)
+            return line_wp_idx, state
+
         return -1, TrafficLight.UNKNOWN
 
 if __name__ == '__main__':

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -92,10 +92,8 @@ class TLDetector(object):
             self.last_state = self.state
             light_wp = light_wp if state == TrafficLight.RED else -1
             self.last_wp = light_wp
-            rospy.loginfo('submitting = '+str(light_wp))
             self.upcoming_red_light_pub.publish(Int32(light_wp))
         else:
-            rospy.loginfo('submitting els = '+str(self.last_wp))
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
         self.state_count += 1
 
@@ -130,7 +128,7 @@ class TLDetector(object):
         #Get classification
         #return self.light_classifier.get_classification(cv_image)
         # TODO: call the claffier instead of using the one you get from simulator.
-        rospy.loginfo('got state = '+str(light.state))
+        rospy.logdebug('got state = '+str(light.state))
         return light.state
 
     def process_traffic_lights(self):
@@ -178,7 +176,6 @@ class TLDetector(object):
                 # list than don't consider it, hence d < diff condition
                 d = temp_wp_idx - car_wp_idx
                 # if the closest
-                #rospy.loginfo("light state "+str(light.state))
                 if d >= 0 and d < diff:
                     diff = d
                     closest_light = light

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -175,7 +175,7 @@ class TLDetector(object):
                 # list than don't consider it, hence d < diff condition
                 d = temp_wp_idx - car_wp_idx
                 # if the closest
-                rospy.loginfo("light state "+str(light.state))
+                #rospy.loginfo("light state "+str(light.state))
                 if d >= 0 and d < diff:
                     diff = d
                     closest_light = light

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -17,6 +17,7 @@ STATE_COUNT_THRESHOLD = 3
 class TLDetector(object):
     def __init__(self):
         rospy.init_node('tl_detector')
+        rospy.loginfo("Inited ")
 
         self.pose = None
         self.waypoints = None
@@ -106,7 +107,7 @@ class TLDetector(object):
             int: index of the closest waypoint in self.waypoints
 
         """
-        return self.__waypoints_tree.query([x, y])[1]
+        return self.__waypoints_tree.query([x, y], 1)[1]
 
     def get_light_state(self, light):
         """Determines the current color of the traffic light
@@ -174,6 +175,7 @@ class TLDetector(object):
                 # list than don't consider it, hence d < diff condition
                 d = temp_wp_idx - car_position
                 # if the closest
+        	rospy.loginfo("light state "+str(lt.state))
                 if d >= 0 and d < diff:
                     diff = d
                     light = lt

--- a/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
@@ -241,7 +241,7 @@ bool PurePursuit::verifyFollowing() const
   if (displacement < displacement_threshold_ && relative_angle < relative_angle_threshold_)
   {
     // ROS_INFO("Following : True");
-    return false;
+    return true;
   }
   else
   {

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -26,7 +26,7 @@ TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
 LOOKAHEAD_WPS = 200 # Number of waypoints we will publish. You can change this number
-MAX_DECEL = 4.0
+MAX_DECEL = 0.5
 
 class WaypointUpdater(object):
     def __init__(self):
@@ -36,7 +36,7 @@ class WaypointUpdater(object):
         rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
 
         # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
-        rospy.Subscriber("/traffic_waypoints", Int32, self.traffic_cb)
+        rospy.Subscriber("/traffic_waypoint", Int32, self.traffic_cb)
 
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
 
@@ -109,7 +109,6 @@ class WaypointUpdater(object):
         msg.waypoints = base_waypoints
         # If you find out that one of the generated waypoints lies on a stop line
         # that we should be stopping at then start decelerating
-        rospy.loginfo('got waypt = '+str(self.__stopline_wp_idx)+' == '+str(idx+LOOKAHEAD_WPS))
         if self.__stopline_wp_idx != -1 and self.__stopline_wp_idx < (idx + LOOKAHEAD_WPS):
             msg.waypoints = self.__decelerate(base_waypoints, idx)
 
@@ -135,7 +134,6 @@ class WaypointUpdater(object):
         return temp
 
     def traffic_cb(self, msg):
-        rospy.loginfo('got msg = '+str(msg.data))
         self.__stopline_wp_idx = msg.data
         pass
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -43,7 +43,7 @@ class WaypointUpdater(object):
         self.__base_waypoints = None
         self.__base_waypoints_array = None
         self.__current_pose = None
-        self.waypoints_tree = None
+        self.__waypoints_tree = None
 
 
     def spin(self, rate=50):
@@ -52,7 +52,7 @@ class WaypointUpdater(object):
         """
         spin_rate = rospy.Rate(rate)
         while not rospy.is_shutdown():
-            if self.__current_pose and self.waypoints_tree:
+            if self.__current_pose and self.__waypoints_tree:
                 idx = self.get_nearest_waypoint_id(self.__current_pose)
                 self.update_waypoints(idx)
 
@@ -67,17 +67,17 @@ class WaypointUpdater(object):
     def waypoints_cb(self, lane):
         # Check out document for PoseStamped Message: http://docs.ros.org/melodic/api/geometry_msgs/html/msg/PoseStamped.html
         rospy.loginfo("Received base waypoints")
-        if not self.waypoints_tree:
+        if not self.__waypoints_tree:
             self.__base_waypoints = lane.waypoints
             self.__base_waypoints_array = [[w.pose.pose.position.x, w.pose.pose.position.y] for w in self.__base_waypoints]
-            self.waypoints_tree = KDTree(self.__base_waypoints_array)
+            self.__waypoints_tree = KDTree(self.__base_waypoints_array)
             rospy.loginfo("Successfully ingested based waypoints")
 
     def get_nearest_waypoint_id(self, pose):
         """
         Returns the nearest waypoint position index for the current pose
         """
-        idx = self.waypoints_tree.query([pose.position.x, pose.position.y])[1]
+        idx = self.__waypoints_tree.query([pose.position.x, pose.position.y])[1]
 
         closest_point = self.__base_waypoints_array[idx]
         previous_point = self.__base_waypoints_array[idx - 1]

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -26,7 +26,7 @@ TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
 LOOKAHEAD_WPS = 200 # Number of waypoints we will publish. You can change this number
-MAX_DECEL = 0.5
+MAX_DECEL = 4.0
 
 class WaypointUpdater(object):
     def __init__(self):
@@ -109,6 +109,7 @@ class WaypointUpdater(object):
         msg.waypoints = base_waypoints
         # If you find out that one of the generated waypoints lies on a stop line
         # that we should be stopping at then start decelerating
+
         if self.__stopline_wp_idx != -1 and self.__stopline_wp_idx < (idx + LOOKAHEAD_WPS):
             msg.waypoints = self.__decelerate(base_waypoints, idx)
 
@@ -134,6 +135,7 @@ class WaypointUpdater(object):
         return temp
 
     def traffic_cb(self, msg):
+        rospy.loginfo('got msg = '+str(msg.data))
         self.__stopline_wp_idx = msg.data
         pass
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -109,7 +109,7 @@ class WaypointUpdater(object):
         msg.waypoints = base_waypoints
         # If you find out that one of the generated waypoints lies on a stop line
         # that we should be stopping at then start decelerating
-
+        rospy.loginfo('got waypt = '+str(self.__stopline_wp_idx)+' == '+str(idx+LOOKAHEAD_WPS))
         if self.__stopline_wp_idx != -1 and self.__stopline_wp_idx < (idx + LOOKAHEAD_WPS):
             msg.waypoints = self.__decelerate(base_waypoints, idx)
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -105,11 +105,15 @@ class WaypointUpdater(object):
 
         msg = Lane()
         msg.header = header
+        # Keep the copy of base_waypoints so that you don't have to recompute them
+        # we are using the same base_waypoints when we get multiple messages for stopping
+        # at a stopline.
         base_waypoints = self.__base_waypoints[idx: idx + LOOKAHEAD_WPS]
         msg.waypoints = base_waypoints
         # If you find out that one of the generated waypoints lies on a stop line
         # that we should be stopping at then start decelerating
         if self.__stopline_wp_idx != -1 and self.__stopline_wp_idx < (idx + LOOKAHEAD_WPS):
+            rospy.logdebug('Planning to stop at '+str(self.__stopline_wp_idx)+' from total '+str(idx + LOOKAHEAD_WPS))
             msg.waypoints = self.__decelerate(base_waypoints, idx)
 
         self.final_waypoints_pub.publish(msg)


### PR DESCRIPTION
I would like to use waypointstree in tl_detector.py as well. Now, I am not an expert programmer of python but the way I pursuit __ variable is that they are private variables (in a way that they shouldn't be touched outside of a class). So, changing the variable name from __ to normal in this pull request. Please merge if you think this is the right thing to do. i.e. change variable name to non-"__"  before accessing it from the tl_detector.py